### PR TITLE
Switched pacstrap to use host package cache, which speeds up container creation

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -6,7 +6,7 @@ import "path/filepath"
 import "strings"
 
 func installPackages(target string, packages []string) error {
-	args := []string{"-d", target}
+	args := []string{"-c", "-d", target}
 	command := exec.Command("pacstrap", append(args, packages...)...)
 
 	output, err := command.CombinedOutput()


### PR DESCRIPTION
Before:

    $ sudo rm -rf /var/lib/hastur/
    $ time sudo hastur -S /bin/ls /
    Container is ephemeral and will be deleted after exit.
    Container will use IP: 10.88.4.182/8
    Spawning container atgep-unmanat-man.hastur on /var/lib/hastur/containers/atgep-unmanat-man/.nspawn.root.
    Press ^] three times within 1s to kill container.
    bin  boot  dev	etc  home  lib	lib64  mnt  opt  proc  root  run  sbin	srv  sys  tmp  usr  var
    Container atgep-unmanat-man.hastur exited successfully.
    
    real	0m11.000s
    user	0m3.080s
    sys	0m0.423s

After:

    $ sudo rm -rf /var/lib/hastur/
    $ time sudo ./hastur -S /bin/ls /
    Container is ephemeral and will be deleted after exit.
    Container will use IP: 10.88.68.200/8
    Spawning container edzod-ohgepoh-vin.hastur on /var/lib/hastur/containers/edzod-ohgepoh-vin/.nspawn.root.
    Press ^] three times within 1s to kill container.
    bin  boot  dev	etc  home  lib	lib64  mnt  opt  proc  root  run  sbin	srv  sys  tmp  usr  var
    Container edzod-ohgepoh-vin.hastur exited successfully.
    
    real	0m4.619s
    user	0m2.880s
    sys	0m0.223s

This is not a particularly scientific test, but it cuts about 60% off the container creation time, with only a trivial change.

This benefit becomes more pronounced with more (and larger) packages to install: adding `-p` to the above tests yields 41.622s without these changes and 16.420s with these changes. Again, that's about a 60% reduction, at least on my computer.